### PR TITLE
Add a loader option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "esbuild-plugin-postcss-literal",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "PostCSS tagged template literals plugin for esbuild.",
 	"repository": "nativew/esbuild-plugin-postcss-literal",
 	"author": "Antoine Boulanger (https://github.com/antoineboulanger)",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const pluginPostcssLiteral = (settings = {}) => ({
 			namespace = '',
 			tag = 'css',
 			minify = false,
+			loader = 'js',
 			config = {}
 		} = settings;
 		let warnings;
@@ -30,7 +31,7 @@ const pluginPostcssLiteral = (settings = {}) => ({
 		const transformContents = async ({ args, contents }) => {
 			const index = contents.indexOf(tag + '`');
 
-			if (index == -1) return { contents };
+			if (index == -1) return { contents, loader };
 
 			const start = index + tag.length + 1;
 			const end = contents.indexOf('`', start);
@@ -55,7 +56,7 @@ const pluginPostcssLiteral = (settings = {}) => ({
 						.warnings()
 						.forEach(warn => process.stderr.write(warn.toString()));
 
-					return { contents };
+					return { contents, loader };
 				})
 				.catch(error => {
 					if (error.name != 'CssSyntaxError') throw error;


### PR DESCRIPTION
When using this plugin with Typescript and other file types with inline CSS, it is useful to be able to specify which loader to use on processed files. It would otherwise default to "js", as per the [esbuild docs](https://esbuild.github.io/plugins/#load-results).

Example usage:
```js
const buildConfig = {
  entryPoints: ["src/index.ts"],
  bundle: true,
  outdir: "dist",
  plugins: [
    postcssLiteral({
      filter: /\.ts/,
      loader: "ts",
    }),
  ]
}
```

Also I'd like to say thanks for making this module. I also tried the postcss and postcss2 (non-inline) plugins and both gave me issues either with shadow DOM or failure to parse when adding Tailwind to my Lit2-based webcomponents project. 👍 