### PR TITLE
Escape special template literal sequences

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const pluginPostcssLiteral = (settings = {}) => ({
 
 			if (result.warnings.length) return (warnings = result.warnings);
 
-			return result.code;
+			return result.code.replace(/([\\`])/g, "\\$&");
 		};
 
 		const transformContents = async ({ args, contents }) => {


### PR DESCRIPTION
Having a ` or backslash in the injected CSS would cause compilation failures in ts/js due to unescaped sequences. This regex simply escapes these. e.g. @tailwindcss/typography uses [both](https://github.com/tailwindlabs/tailwindcss-typography/blob/a71a5570fc88007d623e9e4ac2a558dd6ca0050d/src/styles.js#L132) of [these](https://github.com/tailwindlabs/tailwindcss-typography/blob/a71a5570fc88007d623e9e4ac2a558dd6ca0050d/src/styles.js#L85) things