### PR TITLE
Make warnings non-fatal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const pluginPostcssLiteral = (settings = {}) => ({
 				minify
 			});
 
-			if (result.warnings.length) return (warnings = result.warnings);
+			if (result.warnings.length) warnings = result.warnings;
 
 			return result.code;
 		};
@@ -47,15 +47,13 @@ const pluginPostcssLiteral = (settings = {}) => ({
 				.then(result => {
 					const css = parse(result.css);
 
-					if (warnings) return { warnings };
-
 					contents = contents.slice(0, start) + css + contents.slice(end);
 
 					result
 						.warnings()
 						.forEach(warn => process.stderr.write(warn.toString()));
 
-					return { contents };
+					return { contents, warnings };
 				})
 				.catch(error => {
 					if (error.name != 'CssSyntaxError') throw error;


### PR DESCRIPTION
esbuild will still produce valid CSS even if warnings are encountered. Instead of hard-failing the build just inform the user and carry on.

Currently trying to use @tailwindcss/typography produces warnings due to the use of a [case-sensitive modifier](https://github.com/tailwindlabs/tailwindcss-typography/commit/95bb9eb2807465432dad98d083d7573c4c5b5962#r51665730) on an attribute selector, which esbuild's css interpreter complains about.